### PR TITLE
Provide more memory for docker build

### DIFF
--- a/toolbox/run_local_target.sh
+++ b/toolbox/run_local_target.sh
@@ -44,7 +44,7 @@ echo "StartDate: ${START_DATE}" | tee -a "${REPORT}"
 CPUID=$(cpuid -1 | grep "(synth)" | cut -c14-)
 NUM_CPUS=$(grep -c processor /proc/cpuinfo)
 SMT_ACTIVE=$(cat /sys/devices/system/cpu/smt/active)
-MEMORY_LIMIT_MB="$((NUM_CPUS * 700))"  # ... ought to be enough for anybody.
+MEMORY_LIMIT_MB="$((NUM_CPUS * 2048))"  # ... ought to be enough for anybody.
 if [ "${SMT_ACTIVE}" != "1" ] ; then
     MEMORY_LIMIT_MB="$((MEMORY_LIMIT_MB * 2))"
     CPUID="${CPUID} (SMT disabled)"


### PR DESCRIPTION
"Enough for anybody" but the Intel compiler.
SIRIUS build errors occur with the Intel compiler applying the original memory limitation of 700 MB.