### PR TITLE
Separate dashboard queue and runtime deadlines

### DIFF
--- a/backend/kubernetes_util.py
+++ b/backend/kubernetes_util.py
@@ -16,6 +16,12 @@ from kubernetes.client.models.v1_job_list import V1JobList
 import google.auth.transport.requests
 import google.auth.compute_engine
 
+# A Job deadline includes time spent waiting for a node. Keep the runtime limit
+# on the Pod so queued jobs receive their full execution budget, while retaining
+# a longer Job lifetime limit to bound queueing and retries.
+POD_RUNTIME_LIMIT_SECONDS = 3 * 60 * 60
+JOB_LIFETIME_LIMIT_SECONDS = 12 * 60 * 60
+
 
 class KubernetesUtil:
     def __init__(
@@ -246,6 +252,7 @@ class KubernetesUtil:
             containers=[container],
             volumes=volumes,
             tolerations=[tol_costly, tol_arch],
+            active_deadline_seconds=POD_RUNTIME_LIMIT_SECONDS,
             termination_grace_period_seconds=0,
             restart_policy="OnFailure",  # https://github.com/kubernetes/kubernetes/issues/79398
             dns_policy="Default",  # bypass kube-dns
@@ -263,8 +270,10 @@ class KubernetesUtil:
 
         # job
         job_spec = self.api.V1JobSpec(
-            template=pod_template, backoff_limit=6, active_deadline_seconds=10800
-        )  # 3 hours
+            template=pod_template,
+            backoff_limit=6,
+            active_deadline_seconds=JOB_LIFETIME_LIMIT_SECONDS,
+        )
         job = self.api.V1Job(spec=job_spec, metadata=job_metadata)
         self.batch_api.create_namespaced_job(
             self.namespace, body=job, _request_timeout=self.timeout


### PR DESCRIPTION
## Summary

- enforce the three-hour execution limit on each dashboard Pod
- retain a twelve-hour Job lifetime limit for queueing and retries

## Root cause

Kubernetes counts `Job.spec.activeDeadlineSeconds` from Job creation, including time spent waiting for a node. During the weekly dashboard batch, the Fedora and Address Sanitizer jobs were submitted at 14:03 UTC but only started at 16:39 and 15:53 respectively. Both were terminated around 17:03, exactly three hours after submission, before their dashboard reports could record an `EndDate` or `Status`. This is why they appeared as `UNKNOWN`.

Moving the execution deadline to the Pod starts that budget when the Pod actually starts. The longer Job deadline still bounds queueing and retry lifetime.

## Validation

- `black --check backend/kubernetes_util.py`
- `mypy --strict backend/*.py`
- `python -m compileall -q backend`
- serialized a representative Kubernetes Job manifest and verified a 10800-second Pod deadline and 43200-second Job deadline